### PR TITLE
Add label preview before full generation

### DIFF
--- a/backend/routes/uploads.py
+++ b/backend/routes/uploads.py
@@ -1,7 +1,7 @@
 import json
 from flask import current_app, Blueprint, request, jsonify
 from auth.decorators import verify_session_auth
-from services.label_service import process_label_file
+from services.label_service import process_label_file, generate_label_preview
 from utils.security import validate_file_security, rate_limit, sanitize_input
 import logging
 
@@ -83,3 +83,73 @@ def upload_file():
     except Exception as e:
         logger.exception("Error processing upload for user %s", request.user_id)
         return jsonify({'error': 'An error occurred processing your file'}), 500
+
+
+@uploads_bp.route('/preview', methods=['POST'])
+@rate_limit("10 per hour")
+@verify_session_auth
+def preview_labels():
+    try:
+        if 'file' not in request.files:
+            return jsonify({'error': 'No file provided'}), 400
+
+        file = request.files['file']
+        user_id = request.user_id
+
+        file_size_mb = len(file.read()) / (1024 * 1024)
+        file.seek(0)
+        if file_size_mb > 25:
+            return jsonify({'error': 'File too large. Maximum 25MB.'}), 400
+
+        is_valid, result = validate_file_security(file)
+        if not is_valid:
+            return jsonify({'error': result}), 400
+
+        secure_filename_result = sanitize_input(result)
+
+        template_id = request.form.get('template_id', current_app.config['DEFAULT_TEMPLATE'])
+        templates = current_app.config['LABEL_TEMPLATES']
+        if template_id not in templates:
+            valid = ', '.join(templates.keys())
+            return jsonify({'error': f"Invalid template_id '{template_id}'. Valid templates: {valid}"}), 400
+
+        column_mapping = None
+        column_mapping_raw = request.form.get('column_mapping')
+        if column_mapping_raw:
+            try:
+                mapping = json.loads(column_mapping_raw)
+            except json.JSONDecodeError:
+                return jsonify({'error': 'Invalid column_mapping JSON'}), 400
+
+            barcode_col = mapping.get('barcode_column')
+            if barcode_col is None or not isinstance(barcode_col, int) or barcode_col < 1 or barcode_col > 100:
+                return jsonify({'error': 'barcode_column must be an integer between 1 and 100'}), 400
+
+            column_mapping = {
+                'barcode_column': barcode_col - 1,
+                'text_columns': [
+                    {'column': tc['column'] - 1, 'label': str(tc.get('label', f'Column {tc["column"]}'))[:50]}
+                    for tc in mapping.get('text_columns', [])
+                    if isinstance(tc.get('column'), int) and 1 <= tc['column'] <= 100
+                ],
+                'has_header_row': bool(mapping.get('has_header_row', False))
+            }
+
+        barcode_type = request.form.get('barcode_type', 'code128')
+        if barcode_type not in ('code128', 'qr'):
+            return jsonify({'error': f"Invalid barcode_type '{barcode_type}'. Valid types: code128, qr"}), 400
+
+        result = generate_label_preview(
+            file, user_id, secure_filename_result,
+            template_id=template_id,
+            column_mapping=column_mapping,
+            barcode_type=barcode_type
+        )
+        return jsonify(result)
+
+    except ValueError as e:
+        logger.warning("Preview validation error for user %s", request.user_id)
+        return jsonify({'error': str(e)}), 400
+    except Exception as e:
+        logger.exception("Error generating preview for user %s", request.user_id)
+        return jsonify({'error': 'An error occurred generating the preview'}), 500

--- a/backend/services/label_service.py
+++ b/backend/services/label_service.py
@@ -1,3 +1,4 @@
+import base64
 import pandas as pd
 import uuid
 import time
@@ -152,4 +153,82 @@ def process_label_file(file, user_id, secure_filename, template_id=None, column_
         logger.error("Processing failed, cleaning up temp files.")
         if os.path.exists(filepath):
             os.remove(filepath)
-        raise 
+        raise
+
+
+def generate_label_preview(file, user_id, secure_filename, template_id=None, column_mapping=None, barcode_type='code128'):
+    logger.info("Starting generate_label_preview for user %s", user_id)
+
+    if not column_mapping:
+        column_mapping = {
+            'barcode_column': 1,
+            'text_columns': [
+                {'column': 0, 'label': 'Location'},
+                {'column': 3, 'label': 'Unit'}
+            ],
+            'has_header_row': False
+        }
+
+    ext = os.path.splitext(secure_filename)[1]
+    saved_name = f"{uuid.uuid4().hex}{ext}"
+    filepath = os.path.join(current_app.config['UPLOAD_FOLDER'], saved_name)
+    file.save(filepath)
+
+    try:
+        header_arg = 0 if column_mapping.get('has_header_row') else None
+        if secure_filename.endswith(('.xlsx', '.xls')):
+            df = pd.read_excel(filepath, header=header_arg)
+        else:
+            df = pd.read_csv(filepath, header=header_arg)
+
+        barcode_col = column_mapping['barcode_column']
+        text_cols = column_mapping.get('text_columns', [])
+
+        labels = []
+        for _, row in df.iterrows():
+            if barcode_col >= len(row):
+                continue
+            barcode_value = str(row.iloc[barcode_col]).strip()[:100]
+            if not barcode_value or barcode_value == 'nan':
+                continue
+            text_lines = []
+            for tc in text_cols:
+                col_idx = tc['column']
+                if col_idx < len(row):
+                    val = str(row.iloc[col_idx]).strip()[:100]
+                    if val and val != 'nan':
+                        text_lines.append((tc['label'], val))
+            labels.append((barcode_value, text_lines))
+
+        if not labels:
+            raise ValueError('No valid data found in file')
+
+        label_count = len(labels)
+        if label_count > current_app.config['MAX_LABELS']:
+            raise ValueError(f'Too many labels. Maximum: {current_app.config["MAX_LABELS"]}')
+
+        template = None
+        if template_id:
+            template = current_app.config['LABEL_TEMPLATES'][template_id]
+        sheet_gen = PDFSheetGenerator(current_app.config['SHEET_FOLDER'], template)
+        pdf_bytes = sheet_gen.generate_preview_sheet(labels, barcode_type=barcode_type)
+
+        os.remove(filepath)
+
+        labels_per_sheet = sheet_gen.rows * sheet_gen.columns
+        total_sheets = (label_count + labels_per_sheet - 1) // labels_per_sheet
+
+        logger.info("Preview generated for user %s: %d labels, %d sheets", user_id, label_count, total_sheets)
+
+        return {
+            'preview_pdf': base64.b64encode(pdf_bytes).decode('utf-8'),
+            'label_count': label_count,
+            'total_sheets': total_sheets,
+            'labels_on_first_sheet': min(label_count, labels_per_sheet),
+        }
+
+    except Exception as e:
+        logger.error("Preview generation failed, cleaning up temp files.")
+        if os.path.exists(filepath):
+            os.remove(filepath)
+        raise

--- a/backend/utils/PDFSheetGenerator.py
+++ b/backend/utils/PDFSheetGenerator.py
@@ -1,3 +1,4 @@
+import io
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import LETTER
 from reportlab.lib.units import inch
@@ -73,6 +74,27 @@ class PDFSheetGenerator:
                 x = self.margin_left + col * (self.label_width + self.x_gap)
                 y = LETTER[1] - self.margin_top - (row + 1) * self.label_height - row * self.y_gap
                 c.rect(x, y, self.label_width, self.label_height)
+
+    def generate_preview_sheet(self, labels, barcode_type='code128'):
+        labels_per_sheet = self.rows * self.columns
+        preview_labels = labels[:labels_per_sheet]
+
+        barcode_gen = BarcodeGenerator(self.template, barcode_type=barcode_type)
+        barcode_gen.calibrate([bv for bv, _ in labels])
+
+        buf = io.BytesIO()
+        c = canvas.Canvas(buf, pagesize=LETTER)
+
+        for i, (barcode_value, text_lines) in enumerate(preview_labels):
+            row = i // self.columns
+            col = i % self.columns
+            x = self.margin_left + col * (self.label_width + self.x_gap)
+            y = LETTER[1] - self.margin_top - (row + 1) * self.label_height - row * self.y_gap
+            barcode_gen.draw_label_to_canvas(c, x, y, barcode_value, text_lines)
+
+        c.save()
+        buf.seek(0)
+        return buf.read()
 
     def _get_default_template(self):
         from config.settings import Config

--- a/frontend-vite/react-ts/src/components/LabelPreview.tsx
+++ b/frontend-vite/react-ts/src/components/LabelPreview.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useState } from 'react';
+import { X } from 'lucide-react';
+
+interface LabelPreviewProps {
+  pdfBase64: string;
+  labelCount: number;
+  totalSheets: number;
+  labelsOnFirstSheet: number;
+  onGenerateAll: () => void;
+  onClose: () => void;
+}
+
+function LabelPreview({ pdfBase64, labelCount, totalSheets, labelsOnFirstSheet, onGenerateAll, onClose }: LabelPreviewProps) {
+  const [pdfUrl, setPdfUrl] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const activeUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    setLoaded(false);
+    const bytes = Uint8Array.from(atob(pdfBase64), c => c.charCodeAt(0));
+    const blob = new Blob([bytes], { type: 'application/pdf' });
+    const url = URL.createObjectURL(blob);
+    activeUrlRef.current = url;
+    setPdfUrl(url);
+
+    return () => {
+      URL.revokeObjectURL(url);
+      activeUrlRef.current = null;
+    };
+  }, [pdfBase64]);
+
+  const sheetLabel = totalSheets === 1 ? 'sheet' : 'sheets';
+  const labelLabel = labelCount === 1 ? 'label' : 'labels';
+
+  return (
+    <div className="flex flex-col bg-card border border-border rounded-[16px] overflow-hidden" style={{ height: 'calc(100vh - 6rem)' }}>
+      {/* Header */}
+      <div className="px-6 py-4 border-b border-border flex items-center justify-between flex-shrink-0">
+        <div>
+          <h2 className="font-heading text-sm font-semibold text-foreground">First Sheet Preview</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {labelsOnFirstSheet} of {labelCount} {labelLabel} · {totalSheets} {sheetLabel} total
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={onGenerateAll}
+            className="h-9 px-5 bg-primary text-primary-foreground font-heading text-sm font-medium rounded-full hover:bg-primary/90 transition-colors cursor-pointer"
+          >
+            Generate All
+          </button>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-[10px] text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer bg-transparent border-none"
+            title="Close preview"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* PDF Viewer */}
+      <div className="flex-1 bg-[#3A3A3A] flex items-center justify-center p-6 relative overflow-hidden">
+        {!loaded && (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-white" />
+          </div>
+        )}
+        {pdfUrl && (
+          <iframe
+            src={pdfUrl}
+            title="Label Preview"
+            className={`w-full h-full rounded shadow-2xl transition-opacity duration-200 ${loaded ? 'opacity-100' : 'opacity-0'}`}
+            style={{ border: 'none' }}
+            onLoad={() => setLoaded(true)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default LabelPreview;

--- a/frontend-vite/react-ts/src/components/labelUploader.tsx
+++ b/frontend-vite/react-ts/src/components/labelUploader.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import type { ChangeEvent } from 'react';
 import axios from 'axios';
 import { Upload, Download, Trash2, RefreshCw, FileSpreadsheet, AlertCircle, CheckCircle2, Plus, X } from 'lucide-react';
+import LabelPreview from './LabelPreview';
 
 interface BackendUploadResponse {
   success: boolean;
@@ -20,6 +21,13 @@ interface UserSheet {
   sheet_count: number;
   total_size_bytes: number;
   created_at: string;
+}
+
+interface PreviewData {
+  preview_pdf: string;
+  label_count: number;
+  total_sheets: number;
+  labels_on_first_sheet: number;
 }
 
 function LabelUploader() {
@@ -41,6 +49,8 @@ function LabelUploader() {
   ]);
   const [hasHeaderRow, setHasHeaderRow] = useState(false);
   const [barcodeType, setBarcodeType] = useState<'code128' | 'qr'>('code128');
+  const [previewing, setPreviewing] = useState(false);
+  const [previewData, setPreviewData] = useState<PreviewData | null>(null);
 
   const templates = [
     { id: 'standard_20', name: 'Standard', desc: '20 labels per sheet', size: '1.75" x 1.8"', grid: '5 x 4', rows: 5, cols: 4, maxTextLines: 2 },
@@ -270,6 +280,7 @@ function LabelUploader() {
       console.log(`Total processing time: ${totalTime.toFixed(2)} seconds`);
 
       setFile(null);
+      setPreviewData(null);
       if (fileInputRef.current) fileInputRef.current.value = '';
 
       setTimeout(() => {
@@ -304,6 +315,61 @@ function LabelUploader() {
     }
   };
 
+  const handlePreview = async () => {
+    if (!file) {
+      setError('Please select a file first.');
+      return;
+    }
+
+    const maxSize = 50 * 1024 * 1024;
+    if (file.size > maxSize) {
+      setError('File too large. Maximum size is 50MB.');
+      return;
+    }
+
+    const allowedTypes = ['text/csv', 'application/vnd.ms-excel', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'];
+    if (!allowedTypes.includes(file.type)) {
+      setError('Invalid file type. Please upload a CSV or Excel file.');
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('template_id', selectedTemplate);
+    formData.append('column_mapping', JSON.stringify({
+      barcode_column: barcodeColumn,
+      text_columns: textColumns,
+      has_header_row: hasHeaderRow,
+    }));
+    formData.append('barcode_type', barcodeType);
+
+    setPreviewing(true);
+    setPreviewData(null);
+    setError('');
+    setSuccess('');
+
+    try {
+      const response = await axios.post<PreviewData>(
+        `${API_URL}/preview`,
+        formData,
+        { withCredentials: true }
+      );
+      setPreviewData(response.data);
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        if (err.response?.status === 429) {
+          setError('Preview limit reached. Please wait before trying again.');
+        } else {
+          setError(err.response?.data?.error || 'Failed to generate preview.');
+        }
+      } else {
+        setError('An error occurred generating the preview.');
+      }
+    } finally {
+      setPreviewing(false);
+    }
+  };
+
   const formatFileSize = (bytes: number): string => {
     if (bytes < 1024) return `${bytes} B`;
     if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -315,7 +381,8 @@ function LabelUploader() {
   };
 
   return (
-    <div className="p-6 md:p-10 max-w-5xl">
+    <div className={`p-6 md:p-10 ${previewData ? 'flex gap-6 max-w-none' : 'max-w-5xl'}`}>
+      <div className={previewData ? 'w-[580px] flex-shrink-0' : ''}>
       {/* Page Header */}
       <div className="mb-8">
         <h1 className="font-heading text-2xl font-bold text-foreground">Generate Labels</h1>
@@ -565,10 +632,17 @@ function LabelUploader() {
         </div>
 
         {/* Upload Action */}
-        <div className="px-6 py-4 border-t border-border">
+        <div className="px-6 py-4 border-t border-border flex items-center gap-3">
+          <button
+            onClick={handlePreview}
+            disabled={previewing || loading || !file}
+            className="h-11 px-6 bg-card text-foreground font-heading text-sm font-medium rounded-full border border-border shadow-sm hover:bg-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+          >
+            {previewing ? 'Generating Preview...' : 'Preview First Sheet'}
+          </button>
           <button
             onClick={handleUpload}
-            disabled={loading || !file}
+            disabled={loading || previewing || !file}
             className="h-11 px-6 bg-primary text-primary-foreground font-heading text-sm font-medium rounded-full hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
           >
             {loading ? 'Generating...' : 'Generate Label Sheets'}
@@ -678,6 +752,21 @@ function LabelUploader() {
           </div>
         )}
       </div>
+      </div>
+
+      {/* Preview Panel */}
+      {previewData && (
+        <div className="flex-1 min-w-0 sticky top-6" style={{ height: 'calc(100vh - 6rem)' }}>
+          <LabelPreview
+            pdfBase64={previewData.preview_pdf}
+            labelCount={previewData.label_count}
+            totalSheets={previewData.total_sheets}
+            labelsOnFirstSheet={previewData.labels_on_first_sheet}
+            onGenerateAll={handleUpload}
+            onClose={() => setPreviewData(null)}
+          />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- New `POST /preview` endpoint generates only the first sheet as a base64 PDF — no Supabase storage, no DB writes, 10/hour rate limit
- `PDFSheetGenerator.generate_preview_sheet()` writes to `BytesIO` instead of disk and calibrates bar widths against all labels so the preview is accurate
- New `LabelPreview` component (self-contained) decodes base64 → Blob URL and renders the PDF in an iframe; exposes **Generate All** and **Close** actions
- `labelUploader` switches to a side-by-side layout when a preview is active — form stays on the left (580px), preview panel fills the remaining width and sticks as the user scrolls

## Test plan
- [ ] Upload a CSV, click **Preview First Sheet** — confirm the right panel opens with the correct first-sheet PDF
- [ ] Verify label count and total sheets in the preview header match the file
- [ ] Click **Generate All** from the preview panel — confirm full generation completes and the preview closes
- [ ] Click **X** — confirm the preview panel closes without generating
- [ ] Tweak column mapping or template, re-click **Preview First Sheet** — confirm the preview updates
- [ ] Test with QR barcode type selected — confirm QR codes appear in the preview
- [ ] Test all 4 label templates — confirm layout matches full generation output
- [ ] Hit the preview endpoint 11 times in an hour — confirm 429 is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)