### PR TITLE
Add column mapping onboarding: info icons and first-visit tour

### DIFF
--- a/frontend-vite/react-ts/e2e/column-mapping.spec.ts
+++ b/frontend-vite/react-ts/e2e/column-mapping.spec.ts
@@ -14,15 +14,13 @@ test('barcode column input is visible with a default value', async ({ page }) =>
   expect(parseInt(value)).toBeGreaterThanOrEqual(1);
 });
 
-test('two text field rows are shown by default', async ({ page }) => {
+test('one text field row is shown by default', async ({ page }) => {
   const removeButtons = page.locator('button[title="Remove field"]');
-  await expect(removeButtons).toHaveCount(2);
+  await expect(removeButtons).toHaveCount(1);
 });
 
 test('Add text field button adds a new row for standard_20 template', async ({ page }) => {
-  // standard_20 has max 2 — first remove one to make room
-  const removeButtons = page.locator('button[title="Remove field"]');
-  await removeButtons.first().click();
+  // standard_20 has max 2 — default starts with 1, so Add is already visible
   await page.getByRole('button', { name: /Add text field/ }).click();
   await expect(page.locator('button[title="Remove field"]')).toHaveCount(2);
 });
@@ -30,7 +28,7 @@ test('Add text field button adds a new row for standard_20 template', async ({ p
 test('remove button collapses a text field row', async ({ page }) => {
   const removeButtons = page.locator('button[title="Remove field"]');
   await removeButtons.first().click();
-  await expect(page.locator('button[title="Remove field"]')).toHaveCount(1);
+  await expect(page.locator('button[title="Remove field"]')).toHaveCount(0);
 });
 
 test('header row toggle changes label text', async ({ page }) => {

--- a/frontend-vite/react-ts/src/components/ColumnMappingTour.tsx
+++ b/frontend-vite/react-ts/src/components/ColumnMappingTour.tsx
@@ -1,0 +1,104 @@
+import { useState, useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+import { usePostHog } from '@posthog/react';
+import { X } from 'lucide-react';
+import { BARCODE_COLUMN_HELP, TEXT_FIELDS_HELP, HEADER_ROW_HELP } from './columnMappingHelp';
+import type { HelpContent } from './columnMappingHelp';
+
+const TOUR_KEY = 'lgu_col_map_tour_v1';
+const ALLOWED_ROUTES = ['/dashboard', '/upload'];
+
+const steps: HelpContent[] = [
+  {
+    title: 'Quick note on Column Mapping',
+    body: "Before you generate, make sure the column numbers below match your actual file. It takes 30 seconds and prevents mismatched labels.",
+  },
+  BARCODE_COLUMN_HELP,
+  TEXT_FIELDS_HELP,
+  {
+    ...HEADER_ROW_HELP,
+    body: HEADER_ROW_HELP.body + " That's it — you're ready to generate.",
+  },
+];
+
+export default function ColumnMappingTour() {
+  const location = useLocation();
+  const posthog = usePostHog();
+
+  const [visible, setVisible] = useState(() => {
+    try { return !localStorage.getItem(TOUR_KEY); } catch { return false; }
+  });
+  const [step, setStep] = useState(0);
+  const hasTrackedMount = useRef(false);
+
+  useEffect(() => {
+    if (hasTrackedMount.current) return;
+    if (!visible || !ALLOWED_ROUTES.includes(location.pathname)) return;
+    hasTrackedMount.current = true;
+    posthog?.capture('column_mapping_tour_shown', { step: 0 });
+  }, [visible, location.pathname, posthog]);
+
+  if (!visible || !ALLOWED_ROUTES.includes(location.pathname)) return null;
+
+  const current = steps[step];
+  const isLast = step === steps.length - 1;
+
+  const dismiss = (completed: boolean) => {
+    try { localStorage.setItem(TOUR_KEY, '1'); } catch {}
+    posthog?.capture('column_mapping_tour_dismissed', { step, completed });
+    setVisible(false);
+  };
+
+  return (
+    <div className="fixed bottom-6 right-6 w-80 bg-card border border-border rounded-[16px] shadow-xl p-5 z-50">
+      <div className="flex items-start justify-between mb-3">
+        <p className="text-xs font-semibold text-foreground pr-2">{current.title}</p>
+        <button
+          onClick={() => dismiss(false)}
+          className="flex-shrink-0 p-0.5 rounded text-muted-foreground hover:text-foreground transition-colors bg-transparent border-none cursor-pointer"
+          aria-label="Close"
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      <p className="text-xs text-muted-foreground leading-relaxed mb-3">{current.body}</p>
+
+      {current.example && (
+        <pre className="text-[10px] font-heading bg-secondary/50 rounded-[8px] p-2 whitespace-pre-wrap text-muted-foreground leading-relaxed mb-3">
+          {current.example}
+        </pre>
+      )}
+
+      <div className="flex items-center justify-between mt-1">
+        <div className="flex items-center gap-1.5" role="tablist" aria-label="Tour progress">
+          {steps.map((_, i) => (
+            <span
+              key={i}
+              role="tab"
+              aria-label={`Step ${i + 1} of ${steps.length}`}
+              aria-current={i === step ? 'step' : undefined}
+              className={`w-1.5 h-1.5 rounded-full transition-colors ${i === step ? 'bg-primary' : 'bg-border'}`}
+            />
+          ))}
+        </div>
+        <div className="flex items-center gap-3">
+          {!isLast && (
+            <button
+              onClick={() => dismiss(false)}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors bg-transparent border-none cursor-pointer"
+            >
+              Skip
+            </button>
+          )}
+          <button
+            onClick={() => isLast ? dismiss(true) : setStep(s => s + 1)}
+            className="h-7 px-3 bg-primary text-primary-foreground font-heading text-xs font-medium rounded-full hover:bg-primary/90 transition-colors cursor-pointer border-none"
+          >
+            {isLast ? 'Got it' : 'Next'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend-vite/react-ts/src/components/FieldHelp.tsx
+++ b/frontend-vite/react-ts/src/components/FieldHelp.tsx
@@ -1,0 +1,36 @@
+import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react';
+import { Info } from 'lucide-react';
+import { usePostHog } from '@posthog/react';
+import type { HelpContent } from './columnMappingHelp';
+
+interface FieldHelpProps extends HelpContent {
+  fieldName: string;
+}
+
+export default function FieldHelp({ title, body, example, fieldName }: FieldHelpProps) {
+  const posthog = usePostHog();
+
+  return (
+    <Popover className="relative inline-flex">
+      <PopoverButton
+        aria-label={`More information about ${fieldName.replace(/_/g, ' ')}`}
+        onClick={() => posthog?.capture('column_mapping_help_opened', { field: fieldName })}
+        className="inline-flex items-center justify-center p-0.5 rounded text-muted-foreground hover:text-primary data-[open]:text-primary transition-colors bg-transparent border-none cursor-pointer"
+      >
+        <Info className="w-3.5 h-3.5" />
+      </PopoverButton>
+      <PopoverPanel
+        anchor="bottom start"
+        className="z-50 w-64 bg-card border border-border rounded-[12px] shadow-lg p-4 mt-1"
+      >
+        <p className="text-xs font-semibold text-foreground mb-1.5">{title}</p>
+        <p className="text-xs text-muted-foreground leading-relaxed">{body}</p>
+        {example && (
+          <pre className="mt-2.5 text-[10px] font-heading bg-secondary/50 rounded-[8px] p-2 whitespace-pre-wrap text-muted-foreground leading-relaxed">
+            {example}
+          </pre>
+        )}
+      </PopoverPanel>
+    </Popover>
+  );
+}

--- a/frontend-vite/react-ts/src/components/columnMappingHelp.ts
+++ b/frontend-vite/react-ts/src/components/columnMappingHelp.ts
@@ -1,0 +1,28 @@
+export interface HelpContent {
+  title: string;
+  body: string;
+  example?: string;
+}
+
+export const BARCODE_COLUMN_HELP: HelpContent = {
+  title: 'Which column holds the barcode value?',
+  body: 'Count from the left — column A in your spreadsheet is column 1, column B is column 2, and so on. Enter the number of the column that contains the value to encode (a part number, SKU, or product ID).',
+  example: `Qty | Location | Part Number
+ 4  | 10-02-01  | 4001-PPHT175
+
+→ Part Number is column 3`,
+};
+
+export const TEXT_FIELDS_HELP: HelpContent = {
+  title: 'What text appears on the label?',
+  body: "Each text field prints a human-readable line below the barcode. 'Col' is which column in your file to pull the value from. 'Label' is a short caption printed before that value on the label.",
+  example: `Col: 2 | Label: "Location"
+→ prints "Location: 10-02-01"`,
+};
+
+export const HEADER_ROW_HELP: HelpContent = {
+  title: 'Does your file start with column headers?',
+  body: "If row 1 of your file has column names like 'Part Number' or 'Location' instead of real data, check this box. The app will skip row 1 and start generating labels from row 2.",
+  example: `Row 1 (headers): Qty | Location | Part Number
+Row 2 (first data): 4 | 101-002  | 4001-PPH`,
+};

--- a/frontend-vite/react-ts/src/components/labelUploader.tsx
+++ b/frontend-vite/react-ts/src/components/labelUploader.tsx
@@ -6,6 +6,9 @@ import {
 } from 'lucide-react';
 import { usePostHog } from '@posthog/react';
 import LabelPreview from './LabelPreview';
+import FieldHelp from './FieldHelp';
+import ColumnMappingTour from './ColumnMappingTour';
+import { BARCODE_COLUMN_HELP, TEXT_FIELDS_HELP, HEADER_ROW_HELP } from './columnMappingHelp';
 
 interface BackendUploadResponse {
   success: boolean;
@@ -39,8 +42,7 @@ function LabelUploader() {
   const [selectedTemplate, setSelectedTemplate] = useState('standard_20');
   const [barcodeColumn, setBarcodeColumn] = useState(1);
   const [textColumns, setTextColumns] = useState<{ column: number; label: string }[]>([
-    { column: 1, label: 'Location' },
-    { column: 4, label: 'Unit' },
+    { column: 1, label: '' },
   ]);
   const [hasHeaderRow, setHasHeaderRow] = useState(false);
   const [barcodeType, setBarcodeType] = useState<'code128' | 'qr'>('code128');
@@ -287,12 +289,13 @@ function LabelUploader() {
             <h3 className="font-heading text-sm font-semibold text-foreground mb-1">Column Mapping</h3>
             <p className="text-xs text-muted-foreground mb-4">Tell us which columns in your file contain the barcode value and text to display</p>
             <div className="mb-4">
-              <label className="block text-xs font-medium text-foreground mb-1.5">Barcode Column <span className="text-destructive">*</span></label>
+              <label className="flex items-center gap-1.5 text-xs font-medium text-foreground mb-1.5">Barcode Column <span className="text-destructive">*</span> <FieldHelp {...BARCODE_COLUMN_HELP} fieldName="barcode_column" /></label>
               <input type="number" min={1} max={26} value={barcodeColumn} onChange={(e) => setBarcodeColumn(Math.max(1, Math.min(26, parseInt(e.target.value) || 1)))} className="h-9 w-20 px-3 rounded-[10px] border border-border bg-card text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary" />
               <span className="text-xs text-muted-foreground ml-2">Which column has the barcode value?</span>
             </div>
             <div className="mb-3">
-              <label className="block text-xs font-medium text-foreground mb-1.5">Text Fields {currentTemplate.maxTextLines > 0 && <span className="text-muted-foreground font-normal">(max {currentTemplate.maxTextLines})</span>}</label>
+              <label className="flex items-center gap-1.5 text-xs font-medium text-foreground mb-1">Text Fields {currentTemplate.maxTextLines > 0 && <span className="text-muted-foreground font-normal">(max {currentTemplate.maxTextLines})</span>} <FieldHelp {...TEXT_FIELDS_HELP} fieldName="text_fields" /></label>
+              <p className="text-xs text-muted-foreground mb-2">Optional — adds lines of text to each label. Leave empty for barcode-only labels.</p>
               <div className="flex flex-col gap-2">
                 {textColumns.map((tc, index) => (
                   <div key={index} className="flex items-center gap-2">
@@ -322,6 +325,7 @@ function LabelUploader() {
               </button>
               <span className="text-xs text-foreground">First row is headers</span>
               <span className="text-xs text-muted-foreground">(skip first row when processing)</span>
+              <FieldHelp {...HEADER_ROW_HELP} fieldName="header_row" />
             </div>
           </div>
 
@@ -337,6 +341,8 @@ function LabelUploader() {
         </div>
 
       </div>
+
+      <ColumnMappingTour />
 
       {/* Preview Panel */}
       {previewData && (


### PR DESCRIPTION
## Summary

- **Info icons** added next to Barcode Column, Text Fields, and Header Row labels — clicking opens a popover with a plain-language explanation and a worked example
- **First-visit tour** — a floating card that walks new users through the column mapping section in 4 steps; localStorage-gated so it only appears once, on /dashboard or /upload
- **Shared content constants** — popovers and tour pull from the same file so copy stays in sync
- **Cleared misleading defaults** — replaced pre-filled text field rows (column 1 "Location", column 4 "Unit") with a single blank row to prevent silent misconfiguration
- **PostHog tracking** — column_mapping_tour_shown, column_mapping_tour_dismissed, column_mapping_help_opened events added

## Test plan

- [ ] Log in — tour card should appear on /dashboard bottom-right
- [ ] Step through all 4 tour steps, confirm "Got it" on the last step dismisses it
- [ ] Reload — tour should not reappear
- [ ] Open incognito — tour should reappear
- [ ] Click the info icon next to each of the three column mapping fields — popover opens with correct content
- [ ] Verify column mapping section starts with one blank text field row (no pre-filled Location/Unit values)
- [ ] Check PostHog for the three new events

Generated with [Claude Code](https://claude.com/claude-code)
