### PR TITLE
Fix auth redirect on landing page and inconsistent auth state

### DIFF
--- a/backend/auth/decorators.py
+++ b/backend/auth/decorators.py
@@ -67,6 +67,12 @@ def get_current_user():
     if 'user_id' not in session:
         return None
     
+    if 'access_token_expires' in session:
+        expires_at = datetime.fromisoformat(session['access_token_expires'])
+        if datetime.utcnow() > expires_at:
+            if not refresh_access_token():
+                return None
+            
     return {
         'user_id': session.get('user_id'),
         'user_email': session.get('user_email'),

--- a/frontend-vite/react-ts/src/pages/LandingPage.tsx
+++ b/frontend-vite/react-ts/src/pages/LandingPage.tsx
@@ -6,10 +6,41 @@ import {
   Upload,
   Cpu,
 } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
 import BarcodeWidget from '../components/BarcodeWidget';
 import Navbar from '../components/Navbar';
 
 function LandingPage() {
+  const [authLoading, setAuthLoading] = useState(true);
+  const navigate = useNavigate();
+  const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
+
+  useEffect(() => {
+    const checkAuthStatus = async () => {
+      try {
+        const response = await axios.get(`${API_URL}/auth/status`, { withCredentials: true });
+        if (response.data.authenticated) {
+          navigate('/dashboard', { replace: true });
+        } else {
+          setAuthLoading(false);
+        }
+      } catch {
+        setAuthLoading(false);
+      }
+    };
+    checkAuthStatus();
+  }, []);
+
+  if (authLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-background">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex min-h-screen flex-col bg-background">
       <Navbar />


### PR DESCRIPTION
## Summary

- Authenticated users returning to `/` are now redirected to `/dashboard` instead of seeing the marketing landing page
- `get_current_user()` now validates token expiry and attempts a refresh before returning the user, making `/auth/status` consistent with what `verify_session_auth` enforces on upload/preview endpoints

## Root causes

**Bug 1:** The `/` route rendered `<LandingPage />` unconditionally — only `/login` had an auth check redirect. Returning users with a valid session saw the marketing page with the nav showing them as logged in, but had to navigate to dashboard manually.

**Bug 2:** `get_current_user()` (used by `/auth/status`) only checked `user_id` in session with no token validation. `verify_session_auth` (on `/upload` and `/preview`) checked token expiry and tried to refresh. If a session's access token expired (15 min) and the refresh token was also expired (7 days), the nav and ProtectedRoute showed the user as authenticated while uploads returned 401. Observed via PostHog: users reaching the upload page with no `label_generation_completed` events.

## Changes

- `backend/auth/decorators.py` — `get_current_user()` now checks `access_token_expires`, calls `refresh_access_token()` if expired, and returns `None` if refresh fails
- `frontend-vite/react-ts/src/pages/LandingPage.tsx` — added auth check `useEffect` on mount, redirects to `/dashboard` if authenticated, shows spinner while checking (mirrors existing pattern in `login.tsx`)

## Test plan

- [x] Log in, navigate to `/` — should redirect to `/dashboard`
- [x] Log out, navigate to `/` — should show landing page normally
- [x] Simulate expired tokens (shorten TTLs temporarily) — navigating to a protected route after both tokens expire should redirect to `/login`, not let through and fail on upload
- [x] All existing backend integration tests pass
- [x] All existing Playwright e2e tests pass

Closes #18