### PR TITLE
Fix: sheet delete fails on second identical sheet

### DIFF
--- a/backend/routes/sheets.py
+++ b/backend/routes/sheets.py
@@ -84,6 +84,10 @@ def delete_sheet(user_sheet_id):
     try:
         delete_user_sheet(user_sheet_id, request.user_id)
         return jsonify({'success': True, 'message': 'Sheet deleted successfully'})
+    except LookupError:
+        return jsonify({'error': 'Sheet not found'}), 404
+    except PermissionError:
+        return jsonify({'error': 'Access denied'}), 403
     except Exception as e:
         current_app.logger.error("Error deleting sheet %s: %s", user_sheet_id, e)
-        return jsonify({'error': f'Failed to delete sheet: {str(e)}'}), 500
+        return jsonify({'error': 'Failed to delete sheet'}), 500

--- a/backend/services/sheet_service.py
+++ b/backend/services/sheet_service.py
@@ -121,9 +121,11 @@ def delete_user_sheet(user_sheet_id, user_id):
 
     sheet_response = supabase_admin.table('user_sheets').select('user_id').eq(
         'id', user_sheet_id
-    ).single().execute()
+    ).maybe_single().execute()
 
-    if not sheet_response.data or sheet_response.data['user_id'] != user_id:
+    if not sheet_response.data:
+        raise LookupError('Sheet not found')
+    if sheet_response.data['user_id'] != user_id:
         raise PermissionError('Access denied')
 
     files_response = supabase_admin.table('sheet_files').select(

--- a/frontend-vite/react-ts/src/components/Inventory.tsx
+++ b/frontend-vite/react-ts/src/components/Inventory.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
 import {
   Download, Trash2, RefreshCw, FileSpreadsheet,
@@ -153,7 +153,7 @@ function Inventory() {
     setSheetStates(prev => ({ ...prev, [_userSheetId]: { ...prev[_userSheetId], deleteStatus: 'deleting' } }));
     try {
       await axios.delete(`${API_URL}/delete-sheet/${_userSheetId}`, { withCredentials: true });
-      setUserSheets(userSheets.filter(s => s.id !== _userSheetId));
+      setUserSheets(prev => prev.filter(s => s.id !== _userSheetId));
       setSheetStates(prev => { const n = { ...prev }; delete n[_userSheetId]; return n; });
       if (expandedSheetId === _userSheetId) setExpandedSheetId(null);
     } catch {
@@ -413,8 +413,8 @@ function Inventory() {
                   const numSelected = selectedSheets[sheet.id]?.size ?? 0;
 
                   return (
-                    <>
-                      <tr key={sheet.id} className="hover:bg-secondary/30 transition-colors">
+                    <React.Fragment key={sheet.id}>
+                      <tr className="hover:bg-secondary/30 transition-colors">
                         <td className="px-4 py-3.5">
                           <button
                             onClick={() => toggleExpand(sheet.id)}
@@ -514,7 +514,7 @@ function Inventory() {
                           </td>
                         </tr>
                       )}
-                    </>
+                    </React.Fragment>
                   );
                 })}
               </tbody>


### PR DESCRIPTION
## Summary
- Moves `key` from `<tr>` to `<React.Fragment>` so React reconciles the sheet list by UUID instead of array index, preventing stale `onClick` closures when two visually identical sheets are present
- Uses functional updater in `setUserSheets` to avoid stale closure on delete
- Replaces `.single()` with `.maybe_single()` to prevent an unhandled PGRST116 crash when a sheet is not found
- Splits the old single `PermissionError` into `LookupError` (404) and `PermissionError` (403) so missing sheets return 404 and wrong-owner attempts return 403 instead of a confusing 500

## Related
Closes #21

## Test plan
- [ ] Upload two identical files, delete the first — verify success
- [ ] Delete the second — verify success (previously returned 500)
- [ ] Attempt to delete a non-existent sheet UUID — verify 404
- [ ] Verify delete button is disabled while a delete is in flight (prevents double-click race)